### PR TITLE
Ergänze Leerzeichen im Titel in exportierten VTs

### DIFF
--- a/src/Controller/BerichtController.php
+++ b/src/Controller/BerichtController.php
@@ -660,7 +660,7 @@ class BerichtController extends AbstractController
 
         if ($req) {
             $vvt = $vvtRepository->findBy(array('id' => $req));
-            $title = $this->translator->trans(id: 'processing.export', domain: 'vvt') . $vvt[0]->getName();
+            $title = $this->translator->trans(id: 'processing.export', domain: 'vvt') . ' ' . $vvt[0]->getName();
             $doc = $vvt[0]->getName();
         } else {
             $vvt = $vvtRepository->findBy(array('team' => $team, 'activ' => true));


### PR DESCRIPTION
Dieser PR ergänzt ein fehlendes Leerzeichen in den exportierten PDF zu den Verarbeitungstätigkeiten.

![grafik](https://github.com/Art4/open-datenschutzcenter/assets/2162994/dbcd684e-5d8e-467d-93e7-70f736e0a9a8)
